### PR TITLE
Update method_missing logic on BillingEntity

### DIFF
--- a/bill_forward.gemspec
+++ b/bill_forward.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rest-client', '~> 1.4'
   spec.add_dependency 'json', '~> 1.8.1'
   spec.add_dependency 'require_all'
+  spec.add_dependency 'activesupport'
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rspec"

--- a/lib/bill_forward/billing_entity.rb
+++ b/lib/bill_forward/billing_entity.rb
@@ -146,7 +146,7 @@ module BillForward
 				elements = operand.split('_')
 				camel_cased = elements.join('_').camelize(:lower)
 
-				camel_cased[-1] = camel_cased[-1].upcase if elements.size > 1 && elements.last == 'id'
+				camel_cased.gsub!(/Id/, 'ID') if elements.size > 1 && elements.last =~ /id=?\Z/
 
 				camel_cased
 			end

--- a/lib/bill_forward/billing_entity.rb
+++ b/lib/bill_forward/billing_entity.rb
@@ -6,7 +6,7 @@ module BillForward
 
 		def initialize(state_params = nil, client = nil)
 			raise AbstractInstantiateError.new('This abstract class cannot be instantiated!') if self.class == MutableEntity
-			
+
 			client = self.class.singleton_client if client.nil?
 			state_params = {} if state_params.nil?
 
@@ -20,7 +20,7 @@ module BillForward
 			# initiate with empty state params
 			# use indifferent hash so 'id' and :id are the same
 			@_state_params = HashWithIndifferentAccess.new
-			# legacy Ruby gives us this 'id' chuff. we kinda need it back.	
+			# legacy Ruby gives us this 'id' chuff. we kinda need it back.
 			@_state_params.instance_eval { undef id if defined? id }
 			# populate state params now
 			unserialize_all state_params
@@ -143,14 +143,16 @@ module BillForward
 
 		def method_missing(method_id, *arguments, &block)
 			def camel_case_lower(operand)
-				operand.split('_').reduce('') do |accumulator, iterand|
-					accumulator.empty? \
-						? iterand \
-						: accumulator + iterand.capitalize
-				end
+				elements = operand.split('_')
+				camel_cased = elements.join('_').camelize(:lower)
+
+				camel_cased[-1] = camel_cased[-1].upcase if elements.size > 1 && elements.last == 'id'
+
+				camel_cased
 			end
 
 			qualified = camel_case_lower method_id.to_s
+
 			if qualified != method_id.to_s
 				return self.send(qualified.intern, *arguments)
 			end
@@ -196,7 +198,7 @@ module BillForward
 				field
 			end
 		end
-		
+
 		def to_ordered_hash
 			serialize_field self
 		end

--- a/spec/component/subscription_spec.rb
+++ b/spec/component/subscription_spec.rb
@@ -58,6 +58,13 @@ describe BillForward::Subscription do
 						it 'has product_id at the top' do
 							expect(subscription.product_id).to eq("0CE0A471-A8B1-4E33-B5F4-115947DE8C55")
 						end
+
+                                                it 'can set the product_id to something else' do
+                                                  subscription.product_id = 100
+                                                  expect(subscription.product_id).to eq(100)
+                                                  expect(subscription.productID).to eq(100)
+                                                  expect(subscription['productID']).to eq(100)
+                                                end
 					end
 				end
 				# NOTE: ideally no anonymous entity would exist, because we would register all known nested entities.

--- a/spec/component/subscription_spec.rb
+++ b/spec/component/subscription_spec.rb
@@ -9,27 +9,28 @@ describe BillForward::Subscription do
       # skip OAuth request
       allow_any_instance_of(BillForward::Client).to receive(:get_token).and_return('fake token')
    end
+
 	describe '::get_by_id' do
 		context 'where subscription exists' do
 			describe 'the unserialized subscription' do
+				let(:response) { double :response }
+				let(:subscription_id) { 'ACD66517-6F32-44CB-AF8C-3097F97E1E67' }
+				let(:subscription) { BillForward::Subscription.get_by_id(subscription_id) }
+
+				before do
+					allow(response).to receive(:to_str).and_return(canned_subscription_get)
+					allow(RestClient::Request).to receive(:execute).and_return(response)
+					# mainly just confirm that unserialization is reasonably healthy.
+					expect(subscription.id).to eq(subscription_id)
+				end
+
 				describe '.to_ordered_hash' do
 					context 'using array access' do
 						it "has @type at top" do
-				            subscription_id = 'ACD66517-6F32-44CB-AF8C-3097F97E1E67'
-
-				            response = double
-				            allow(response).to receive(:to_str).and_return(canned_subscription_get)
-				            allow(RestClient::Request).to receive(:execute).and_return(response)
-
-				            subscription = BillForward::Subscription.get_by_id subscription_id
-
-				            # mainly just confirm that unserialization is reasonably healthy.
-				            expect(subscription.id).to eq(subscription_id)
-
-				            # check that @type is the first key on subscription (we use ordered hashes)
-				            payload = subscription.to_ordered_hash
-				            payload_first_kvp = payload.first
-				            kvp_key  = payload_first_kvp.first
+							# check that @type is the first key on subscription (we use ordered hashes)
+							payload = subscription.to_ordered_hash
+							payload_first_kvp = payload.first
+							kvp_key  = payload_first_kvp.first
 							expect(kvp_key).to eq('@type')
 
 							# check that @type is the first key on nested entities (we use ordered hashes)
@@ -41,17 +42,6 @@ describe BillForward::Subscription do
 					end
 					context 'using dot access' do
 						it "has @type at top" do
-				            subscription_id = 'ACD66517-6F32-44CB-AF8C-3097F97E1E67'
-
-				            response = double
-				            allow(response).to receive(:to_str).and_return(canned_subscription_get)
-				            allow(RestClient::Request).to receive(:execute).and_return(response)
-
-				            subscription = BillForward::Subscription.get_by_id subscription_id
-
-				            # mainly just confirm that unserialization is reasonably healthy.
-				            expect(subscription.id).to eq(subscription_id)
-
 				            # check that @type is the first key on subscription (we use ordered hashes)
 				            payload = subscription.to_ordered_hash
 				            payload_first_kvp = payload.first
@@ -64,6 +54,10 @@ describe BillForward::Subscription do
 							kvp_key  = pricing_component_first_kvp.first
 							expect(kvp_key).to eq('@type')
 						end
+
+						it 'has product_id at the top' do
+							expect(subscription.product_id).to eq("0CE0A471-A8B1-4E33-B5F4-115947DE8C55")
+						end
 					end
 				end
 				# NOTE: ideally no anonymous entity would exist, because we would register all known nested entities.
@@ -74,26 +68,10 @@ describe BillForward::Subscription do
 				describe 'nested anonymous entity' do
 					context 'using dot access' do
 						it "can be read" do
-				            subscription_id = 'ACD66517-6F32-44CB-AF8C-3097F97E1E67'
-
-				            response = double
-				            allow(response).to receive(:to_str).and_return(canned_subscription_get)
-				            allow(RestClient::Request).to receive(:execute).and_return(response)
-
-				            subscription = BillForward::Subscription.get_by_id subscription_id
-
 							a_pricing_component = subscription.productRatePlan.pricingComponents.first
 							expect(a_pricing_component.name).to eq('Devices used, fixed')
 						end
 						it "can be changed" do
-				            subscription_id = 'ACD66517-6F32-44CB-AF8C-3097F97E1E67'
-
-				            response = double
-				            allow(response).to receive(:to_str).and_return(canned_subscription_get)
-				            allow(RestClient::Request).to receive(:execute).and_return(response)
-
-				            subscription = BillForward::Subscription.get_by_id subscription_id
-
 							a_pricing_component = subscription.productRatePlan.pricingComponents.first
 							expect(a_pricing_component.name).to eq('Devices used, fixed')
 
@@ -105,26 +83,10 @@ describe BillForward::Subscription do
 					end
 					context 'using array access' do
 						it "can be read" do
-				            subscription_id = 'ACD66517-6F32-44CB-AF8C-3097F97E1E67'
-
-				            response = double
-				            allow(response).to receive(:to_str).and_return(canned_subscription_get)
-				            allow(RestClient::Request).to receive(:execute).and_return(response)
-
-				            subscription = BillForward::Subscription.get_by_id subscription_id
-
 							a_pricing_component = subscription['productRatePlan']['pricingComponents'].first
 							expect(a_pricing_component['name']).to eq('Devices used, fixed')
 						end
 						it "can be changed" do
-				            subscription_id = 'ACD66517-6F32-44CB-AF8C-3097F97E1E67'
-
-				            response = double
-				            allow(response).to receive(:to_str).and_return(canned_subscription_get)
-				            allow(RestClient::Request).to receive(:execute).and_return(response)
-
-				            subscription = BillForward::Subscription.get_by_id subscription_id
-
 							a_pricing_component = subscription['productRatePlan']['pricingComponents'].first
 							expect(a_pricing_component['name']).to eq('Devices used, fixed')
 


### PR DESCRIPTION
This change allows attributes that end in ID to be accessible via snake_case attribute names

E.G productID should be accessible as `product_id` rather than `product_i_d`